### PR TITLE
Bug fix on dashboard weekly/monthly view button

### DIFF
--- a/clear/app/javascript/controllers/calendar_view_controller.js
+++ b/clear/app/javascript/controllers/calendar_view_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const DASHBOARD_VIEW_TOGGLE_NAME = "calendar_dashboard_view"
+const DASHBOARD_VIEW_TOGGLE_NAME = "calendar_dashboard"
 
 export default class extends Controller {
   static targets = ["weeklyWrapper", "monthlyWrapper"]


### PR DESCRIPTION
This is a bug. 
<img width="2741" height="1566" alt="image" src="https://github.com/user-attachments/assets/9ff34504-70c3-446b-bc51-c4d5621e554e" />

This issue fixes that. For the acceptance plan. You'd want to replicate the bug on main then try it on this branch. Here is the step: 
1) Go on weekly view then press weekly view on the dropdown then go to monthly on main. 
2) You should get a monthly view while the dropdown says weekly.

Now that you replicated the error. Then, try again on this branch . The error shouldn't happen.